### PR TITLE
Add Beneficiario resource controller with validation and search

### DIFF
--- a/backend/Sys_IPJ_2025/app/Http/Controllers/BeneficiarioController.php
+++ b/backend/Sys_IPJ_2025/app/Http/Controllers/BeneficiarioController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Beneficiario;
+use Illuminate\Http\Request;
+use App\Http\Requests\BeneficiarioRequest;
+
+class BeneficiarioController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        $search = $request->query('search');
+
+        $beneficiarios = Beneficiario::query()
+            ->when($search, function ($query, $search) {
+                $query->where('curp', 'like', "%{$search}%")
+                      ->orWhere('folio_tarjeta', 'like', "%{$search}%");
+            })
+            ->get();
+
+        return response()->json($beneficiarios);
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(BeneficiarioRequest $request)
+    {
+        $beneficiario = Beneficiario::create($request->validated());
+
+        return response()->json($beneficiario, 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Beneficiario $beneficiario)
+    {
+        return response()->json($beneficiario);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Beneficiario $beneficiario)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(BeneficiarioRequest $request, Beneficiario $beneficiario)
+    {
+        $beneficiario->update($request->validated());
+
+        return response()->json($beneficiario);
+    }
+}

--- a/backend/Sys_IPJ_2025/app/Http/Requests/BeneficiarioRequest.php
+++ b/backend/Sys_IPJ_2025/app/Http/Requests/BeneficiarioRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BeneficiarioRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'folio_tarjeta' => ['required', 'string'],
+            'nombre' => ['required', 'string'],
+            'curp' => ['required', 'string'],
+        ];
+    }
+}

--- a/backend/Sys_IPJ_2025/app/Models/Beneficiario.php
+++ b/backend/Sys_IPJ_2025/app/Models/Beneficiario.php
@@ -10,6 +10,15 @@ class Beneficiario extends Model
     use HasFactory;
 
     /**
+     * The attributes that are mass assignable.
+     */
+    protected $fillable = [
+        'nombre',
+        'curp',
+        'folio_tarjeta',
+    ];
+
+    /**
      * Get the domicilio associated with the beneficiario.
      */
     public function domicilio()

--- a/backend/Sys_IPJ_2025/routes/web.php
+++ b/backend/Sys_IPJ_2025/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\BeneficiarioController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::resource('beneficiarios', BeneficiarioController::class)->except(['destroy']);


### PR DESCRIPTION
## Summary
- add BeneficiarioController with CRUD methods and CURP/folio search
- validate folio_tarjeta, nombre and curp via BeneficiarioRequest
- allow mass assignment on Beneficiario model and register resource routes

## Testing
- `php -l backend/Sys_IPJ_2025/app/Http/Controllers/BeneficiarioController.php`
- `php -l backend/Sys_IPJ_2025/app/Http/Requests/BeneficiarioRequest.php`
- `php -l backend/Sys_IPJ_2025/app/Models/Beneficiario.php`
- `php -l backend/Sys_IPJ_2025/routes/web.php`
- `php artisan test` *(fails: vendor/autoload.php not found)*
- `composer install` *(fails: laravel/breeze missing from lock file)*
- `composer update` *(fails: curl 56 CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fa984cc0832f8fb958a6c2951165