### PR TITLE
Add DomicilioController for beneficiary addresses

### DIFF
--- a/backend/Sys_IPJ_2025/app/Http/Controllers/DomicilioController.php
+++ b/backend/Sys_IPJ_2025/app/Http/Controllers/DomicilioController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\DomicilioRequest;
+use App\Models\Beneficiario;
+use App\Models\Domicilio;
+
+class DomicilioController extends Controller
+{
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create(Beneficiario $beneficiario)
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(DomicilioRequest $request, Beneficiario $beneficiario)
+    {
+        $domicilio = $beneficiario->domicilio()->create($request->validated());
+
+        return response()->json($domicilio, 201);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Domicilio $domicilio)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(DomicilioRequest $request, Domicilio $domicilio)
+    {
+        $domicilio->update($request->validated());
+
+        return response()->json($domicilio);
+    }
+}

--- a/backend/Sys_IPJ_2025/app/Http/Requests/DomicilioRequest.php
+++ b/backend/Sys_IPJ_2025/app/Http/Requests/DomicilioRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DomicilioRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'calle' => ['required', 'string'],
+            'numero' => ['nullable', 'string'],
+            'colonia' => ['nullable', 'string'],
+            'cp' => ['nullable', 'string', 'max:10'],
+        ];
+    }
+}

--- a/backend/Sys_IPJ_2025/app/Models/Domicilio.php
+++ b/backend/Sys_IPJ_2025/app/Models/Domicilio.php
@@ -10,6 +10,16 @@ class Domicilio extends Model
     use HasFactory;
 
     /**
+     * The attributes that are mass assignable.
+     */
+    protected $fillable = [
+        'calle',
+        'numero',
+        'colonia',
+        'cp',
+    ];
+
+    /**
      * Get the beneficiario that owns the domicilio.
      */
     public function beneficiario()

--- a/backend/Sys_IPJ_2025/routes/web.php
+++ b/backend/Sys_IPJ_2025/routes/web.php
@@ -2,9 +2,14 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\BeneficiarioController;
+use App\Http\Controllers\DomicilioController;
 
 Route::get('/', function () {
     return view('welcome');
 });
 
 Route::resource('beneficiarios', BeneficiarioController::class)->except(['destroy']);
+
+Route::resource('beneficiarios.domicilio', DomicilioController::class)
+    ->shallow()
+    ->only(['create', 'store', 'edit', 'update']);


### PR DESCRIPTION
## Summary
- add controller to manage beneficiary domiciles
- validate domicile data
- expose nested routes for creating and updating domiciles

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fbaa9a0c832f8ed7b478213b2c7b