### PR TITLE
Add period and group management views with enrollment

### DIFF
--- a/backend/Sys_IPJ_2025/app/Http/Controllers/PeriodoManejoController.php
+++ b/backend/Sys_IPJ_2025/app/Http/Controllers/PeriodoManejoController.php
@@ -11,10 +11,32 @@ class PeriodoManejoController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request)
     {
-        $periodos = PeriodoManejo::orderByDesc('anio')->orderByDesc('mes')->paginate(10);
-        return view('periodos.index', compact('periodos'));
+        $anio = $request->input('anio');
+        $mes = $request->input('mes');
+
+        $query = PeriodoManejo::query();
+
+        if ($anio) {
+            $query->where('anio', $anio);
+        }
+
+        if ($mes) {
+            $query->where('mes', $mes);
+        }
+
+        $periodos = $query
+            ->orderByDesc('anio')
+            ->orderByDesc('mes')
+            ->paginate(10)
+            ->withQueryString();
+
+        return view('periodos.index', [
+            'periodos' => $periodos,
+            'anio' => $anio,
+            'mes' => $mes,
+        ]);
     }
 
     /**
@@ -40,10 +62,20 @@ class PeriodoManejoController extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(PeriodoManejo $periodo)
+    public function show(PeriodoManejo $periodo, Request $request)
     {
-        $periodo->load('grupos');
-        return view('periodos.show', compact('periodo'));
+        $horario = $request->input('horario');
+
+        $periodo->load(['grupos' => function ($query) use ($horario) {
+            if ($horario) {
+                $query->where('horario', 'like', "%$horario%");
+            }
+        }]);
+
+        return view('periodos.show', [
+            'periodo' => $periodo,
+            'horario' => $horario,
+        ]);
     }
 
     /**

--- a/backend/Sys_IPJ_2025/resources/views/grupos/create.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/grupos/create.blade.php
@@ -1,0 +1,8 @@
+<x-layout title="Nuevo grupo">
+    <h1 class="h3 mb-3">Nuevo grupo</h1>
+    <form method="POST" action="{{ route('grupos.store') }}">
+        @csrf
+        @include('grupos.form')
+    </form>
+</x-layout>
+

--- a/backend/Sys_IPJ_2025/resources/views/grupos/edit.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/grupos/edit.blade.php
@@ -1,0 +1,9 @@
+<x-layout :title="'Editar grupo ' . $grupo->id">
+    <h1 class="h3 mb-3">Editar grupo</h1>
+    <form method="POST" action="{{ route('grupos.update', $grupo) }}">
+        @csrf
+        @method('PUT')
+        @include('grupos.form', ['grupo' => $grupo])
+    </form>
+</x-layout>
+

--- a/backend/Sys_IPJ_2025/resources/views/grupos/form.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/grupos/form.blade.php
@@ -1,0 +1,19 @@
+<div class="mb-3">
+    <label for="periodo_id" class="form-label">Periodo</label>
+    <select name="periodo_id" id="periodo_id" class="form-select">
+        @foreach ($periodos as $periodo)
+            <option value="{{ $periodo->id }}" @selected(old('periodo_id', $grupo->periodo_id ?? null) == $periodo->id)>
+                {{ $periodo->mes }}/{{ $periodo->anio }}
+            </option>
+        @endforeach
+    </select>
+    @error('periodo_id')
+        <div class="text-danger small">{{ $message }}</div>
+    @enderror
+</div>
+<x-form.input name="horario" label="Horario" :value="$grupo->horario ?? null" />
+<x-form.input name="cupo_total" label="Cupo total" type="number" :value="$grupo->cupo_total ?? null" />
+<div class="text-end">
+    <button type="submit" class="btn btn-primary">Guardar</button>
+</div>
+

--- a/backend/Sys_IPJ_2025/resources/views/grupos/index.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/grupos/index.blade.php
@@ -1,0 +1,48 @@
+<x-layout title="Grupos">
+    <div class="d-flex justify-content-between mb-3">
+        <form method="GET" class="row row-cols-lg-auto g-2 align-items-center">
+            <div class="col">
+                <select name="periodo_id" class="form-select">
+                    <option value="">Periodo</option>
+                    @foreach ($periodos as $periodo)
+                        <option value="{{ $periodo->id }}" @selected($periodo_id == $periodo->id)>
+                            {{ $periodo->mes }}/{{ $periodo->anio }}
+                        </option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="col">
+                <input type="text" name="horario" class="form-control" placeholder="Horario" value="{{ $horario }}">
+            </div>
+            <div class="col">
+                <button type="submit" class="btn btn-secondary">Filtrar</button>
+            </div>
+        </form>
+        <a href="{{ route('grupos.create') }}" class="btn btn-primary">Nuevo</a>
+    </div>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Periodo</th>
+                <th>Horario</th>
+                <th>Cupo utilizado</th>
+                <th class="text-end">Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($grupos as $grupo)
+                <tr>
+                    <td>{{ $grupo->periodo->mes }}/{{ $grupo->periodo->anio }}</td>
+                    <td>{{ $grupo->horario }}</td>
+                    <td>{{ $grupo->total_hombres + $grupo->total_mujeres }} / {{ $grupo->cupo_total }}</td>
+                    <td class="text-end">
+                        <a href="{{ route('grupos.show', $grupo) }}" class="btn btn-sm btn-info">Ver</a>
+                        <a href="{{ route('grupos.edit', $grupo) }}" class="btn btn-sm btn-warning">Editar</a>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+    {{ $grupos->links() }}
+</x-layout>
+

--- a/backend/Sys_IPJ_2025/resources/views/grupos/show.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/grupos/show.blade.php
@@ -1,0 +1,53 @@
+<x-layout :title="'Grupo ' . $grupo->id">
+    <h1 class="h3 mb-3">Grupo {{ $grupo->horario }} - {{ $grupo->periodo->mes }}/{{ $grupo->periodo->anio }}</h1>
+    <p>Cupo utilizado: {{ $grupo->total_hombres + $grupo->total_mujeres }} / {{ $grupo->cupo_total }}</p>
+
+    @if ($errors->any())
+        <div class="alert alert-danger">{{ $errors->first() }}</div>
+    @endif
+
+    <h2 class="h4 mt-4">Inscripciones</h2>
+    <form method="POST" action="{{ route('inscripciones.store') }}" class="row row-cols-lg-auto g-2 align-items-center mb-3">
+        @csrf
+        <input type="hidden" name="grupo_id" value="{{ $grupo->id }}">
+        <div class="col">
+            <select name="beneficiario_id" class="form-select">
+                @foreach ($beneficiarios as $beneficiario)
+                    <option value="{{ $beneficiario->id }}">{{ $beneficiario->nombre }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div class="col">
+            <button type="submit" class="btn btn-primary">Inscribir</button>
+        </div>
+    </form>
+    @error('beneficiario_id')
+        <div class="text-danger small mb-3">{{ $message }}</div>
+    @enderror
+
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Beneficiario</th>
+                <th>CURP</th>
+                <th class="text-end">Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($grupo->inscripciones as $inscripcion)
+                <tr>
+                    <td>{{ $inscripcion->beneficiario->nombre }}</td>
+                    <td>{{ $inscripcion->beneficiario->curp }}</td>
+                    <td class="text-end">
+                        <form method="POST" action="{{ route('inscripciones.destroy', $inscripcion) }}">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-sm btn-danger">Baja</button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</x-layout>
+

--- a/backend/Sys_IPJ_2025/resources/views/periodos/create.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/periodos/create.blade.php
@@ -1,0 +1,8 @@
+<x-layout title="Nuevo periodo">
+    <h1 class="h3 mb-3">Nuevo periodo</h1>
+    <form method="POST" action="{{ route('periodos.store') }}">
+        @csrf
+        @include('periodos.form')
+    </form>
+</x-layout>
+

--- a/backend/Sys_IPJ_2025/resources/views/periodos/edit.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/periodos/edit.blade.php
@@ -1,0 +1,9 @@
+<x-layout :title="'Editar periodo ' . $periodo->mes . '/' . $periodo->anio">
+    <h1 class="h3 mb-3">Editar periodo</h1>
+    <form method="POST" action="{{ route('periodos.update', $periodo) }}">
+        @csrf
+        @method('PUT')
+        @include('periodos.form', ['periodo' => $periodo])
+    </form>
+</x-layout>
+

--- a/backend/Sys_IPJ_2025/resources/views/periodos/form.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/periodos/form.blade.php
@@ -1,0 +1,6 @@
+<x-form.input name="anio" label="Año" type="number" :value="$periodo->anio ?? null" />
+<x-form.input name="mes" label="Mes" type="number" :value="$periodo->mes ?? null" />
+<div class="text-end">
+    <button type="submit" class="btn btn-primary">Guardar</button>
+</div>
+

--- a/backend/Sys_IPJ_2025/resources/views/periodos/index.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/periodos/index.blade.php
@@ -1,0 +1,39 @@
+<x-layout title="Periodos">
+    <div class="d-flex justify-content-between mb-3">
+        <form method="GET" class="row row-cols-lg-auto g-2 align-items-center">
+            <div class="col">
+                <input type="number" name="anio" class="form-control" placeholder="Año" value="{{ $anio }}">
+            </div>
+            <div class="col">
+                <input type="number" name="mes" class="form-control" placeholder="Mes" value="{{ $mes }}">
+            </div>
+            <div class="col">
+                <button type="submit" class="btn btn-secondary">Filtrar</button>
+            </div>
+        </form>
+        <a href="{{ route('periodos.create') }}" class="btn btn-primary">Nuevo</a>
+    </div>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Año</th>
+                <th>Mes</th>
+                <th class="text-end">Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($periodos as $periodo)
+                <tr>
+                    <td>{{ $periodo->anio }}</td>
+                    <td>{{ $periodo->mes }}</td>
+                    <td class="text-end">
+                        <a href="{{ route('periodos.show', $periodo) }}" class="btn btn-sm btn-info">Ver</a>
+                        <a href="{{ route('periodos.edit', $periodo) }}" class="btn btn-sm btn-warning">Editar</a>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+    {{ $periodos->links() }}
+</x-layout>
+

--- a/backend/Sys_IPJ_2025/resources/views/periodos/show.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/periodos/show.blade.php
@@ -1,0 +1,32 @@
+<x-layout :title="'Periodo ' . $periodo->mes . '/' . $periodo->anio">
+    <h1 class="h3 mb-3">Periodo {{ $periodo->mes }}/{{ $periodo->anio }}</h1>
+    <form method="GET" class="row row-cols-lg-auto g-2 align-items-center mb-3">
+        <div class="col">
+            <input type="text" name="horario" class="form-control" placeholder="Horario" value="{{ $horario }}">
+        </div>
+        <div class="col">
+            <button type="submit" class="btn btn-secondary">Filtrar</button>
+        </div>
+    </form>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Horario</th>
+                <th>Cupo utilizado</th>
+                <th class="text-end">Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($periodo->grupos as $grupo)
+                <tr>
+                    <td>{{ $grupo->horario }}</td>
+                    <td>{{ $grupo->total_hombres + $grupo->total_mujeres }} / {{ $grupo->cupo_total }}</td>
+                    <td class="text-end">
+                        <a href="{{ route('grupos.show', $grupo) }}" class="btn btn-sm btn-info">Ver</a>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</x-layout>
+


### PR DESCRIPTION
## Summary
- add filters for periods and groups in controllers
- implement period and group blade views showing used capacity and letting users enroll or remove beneficiaries

## Testing
- `composer install` *(fails: Required package "laravel/breeze" is not present in the lock file)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b2030e4f94832f954a2b4ac9579603