### PR TITLE
Add nomada topic and conference controllers

### DIFF
--- a/backend/Sys_IPJ_2025/app/Http/Controllers/ConferenciaNomadaController.php
+++ b/backend/Sys_IPJ_2025/app/Http/Controllers/ConferenciaNomadaController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ConferenciaNomada;
+use App\Http\Requests\ConferenciaNomadaRequest;
+use Illuminate\Http\Request;
+
+class ConferenciaNomadaController extends Controller
+{
+    public function index(Request $request)
+    {
+        $mes = $request->query('mes');
+        $municipio = $request->query('municipio');
+
+        $conferencias = ConferenciaNomada::query()
+            ->when($mes, fn($q) => $q->whereMonth('fecha', $mes))
+            ->when($municipio, fn($q) => $q->where('municipio', $municipio))
+            ->with('tema')
+            ->get();
+
+        return response()->json($conferencias);
+    }
+
+    public function store(ConferenciaNomadaRequest $request)
+    {
+        $conferencia = ConferenciaNomada::create($request->validated());
+
+        return response()->json($conferencia, 201);
+    }
+
+    public function show(ConferenciaNomada $conferencia_nomada)
+    {
+        return response()->json($conferencia_nomada->load('tema'));
+    }
+
+    public function update(ConferenciaNomadaRequest $request, ConferenciaNomada $conferencia_nomada)
+    {
+        $conferencia_nomada->update($request->validated());
+
+        return response()->json($conferencia_nomada);
+    }
+
+    public function destroy(ConferenciaNomada $conferencia_nomada)
+    {
+        $conferencia_nomada->delete();
+
+        return response()->noContent();
+    }
+}

--- a/backend/Sys_IPJ_2025/app/Http/Controllers/TemaNomadaController.php
+++ b/backend/Sys_IPJ_2025/app/Http/Controllers/TemaNomadaController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TemaNomada;
+use App\Http\Requests\TemaNomadaRequest;
+use Illuminate\Http\Request;
+
+class TemaNomadaController extends Controller
+{
+    public function index()
+    {
+        return response()->json(TemaNomada::all());
+    }
+
+    public function store(TemaNomadaRequest $request)
+    {
+        $tema = TemaNomada::create($request->validated());
+
+        return response()->json($tema, 201);
+    }
+
+    public function show(TemaNomada $tema_nomada)
+    {
+        return response()->json($tema_nomada->load('conferencias'));
+    }
+
+    public function update(TemaNomadaRequest $request, TemaNomada $tema_nomada)
+    {
+        $tema_nomada->update($request->validated());
+
+        return response()->json($tema_nomada);
+    }
+
+    public function destroy(TemaNomada $tema_nomada)
+    {
+        $tema_nomada->delete();
+
+        return response()->noContent();
+    }
+}

--- a/backend/Sys_IPJ_2025/app/Http/Requests/ConferenciaNomadaRequest.php
+++ b/backend/Sys_IPJ_2025/app/Http/Requests/ConferenciaNomadaRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ConferenciaNomadaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'tema_nomada_id' => ['required', 'exists:tema_nomadas,id'],
+            'titulo' => ['required', 'string', 'max:255'],
+            'fecha' => ['required', 'date'],
+            'municipio' => ['required', 'string', 'max:255'],
+            'descripcion' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/backend/Sys_IPJ_2025/app/Http/Requests/TemaNomadaRequest.php
+++ b/backend/Sys_IPJ_2025/app/Http/Requests/TemaNomadaRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TemaNomadaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'nombre' => [
+                'required',
+                'string',
+                Rule::unique('tema_nomadas')->ignore($this->route('tema_nomada')),
+            ],
+            'descripcion' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/backend/Sys_IPJ_2025/app/Models/ConferenciaNomada.php
+++ b/backend/Sys_IPJ_2025/app/Models/ConferenciaNomada.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ConferenciaNomada extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'tema_nomada_id',
+        'titulo',
+        'fecha',
+        'municipio',
+        'descripcion',
+    ];
+
+    protected $casts = [
+        'fecha' => 'date',
+    ];
+
+    public function tema()
+    {
+        return $this->belongsTo(TemaNomada::class, 'tema_nomada_id');
+    }
+}

--- a/backend/Sys_IPJ_2025/app/Models/TemaNomada.php
+++ b/backend/Sys_IPJ_2025/app/Models/TemaNomada.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TemaNomada extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'nombre',
+        'descripcion',
+    ];
+
+    public function conferencias()
+    {
+        return $this->hasMany(ConferenciaNomada::class);
+    }
+}

--- a/backend/Sys_IPJ_2025/database/migrations/2024_01_01_000011_create_tema_nomadas_table.php
+++ b/backend/Sys_IPJ_2025/database/migrations/2024_01_01_000011_create_tema_nomadas_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tema_nomadas', function (Blueprint $table) {
+            $table->id();
+            $table->string('nombre');
+            $table->text('descripcion')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tema_nomadas');
+    }
+};

--- a/backend/Sys_IPJ_2025/database/migrations/2024_01_01_000012_create_conferencia_nomadas_table.php
+++ b/backend/Sys_IPJ_2025/database/migrations/2024_01_01_000012_create_conferencia_nomadas_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('conferencia_nomadas', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tema_nomada_id')->constrained('tema_nomadas')->onDelete('cascade');
+            $table->string('titulo');
+            $table->date('fecha');
+            $table->string('municipio');
+            $table->text('descripcion')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('conferencia_nomadas');
+    }
+};

--- a/backend/Sys_IPJ_2025/routes/web.php
+++ b/backend/Sys_IPJ_2025/routes/web.php
@@ -7,6 +7,8 @@ use App\Http\Controllers\ProgramaController;
 use App\Http\Controllers\PeriodoManejoController;
 use App\Http\Controllers\GrupoManejoController;
 use App\Http\Controllers\InscripcionManejoController;
+use App\Http\Controllers\TemaNomadaController;
+use App\Http\Controllers\ConferenciaNomadaController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -40,3 +42,6 @@ Route::post('inscripciones', [InscripcionManejoController::class, 'store'])
     ->name('inscripciones.store');
 Route::delete('inscripciones/{inscripcion}', [InscripcionManejoController::class, 'destroy'])
     ->name('inscripciones.destroy');
+
+Route::resource('temas-nomada', TemaNomadaController::class);
+Route::resource('conferencias-nomada', ConferenciaNomadaController::class);

--- a/backend/Sys_IPJ_2025/tests/Feature/ConferenciaNomadaTest.php
+++ b/backend/Sys_IPJ_2025/tests/Feature/ConferenciaNomadaTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\TemaNomada;
+use App\Models\ConferenciaNomada;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConferenciaNomadaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_filtrar_por_mes(): void
+    {
+        $tema = TemaNomada::create(['nombre' => 'Salud']);
+        ConferenciaNomada::create([
+            'tema_nomada_id' => $tema->id,
+            'titulo' => 'Conferencia mayo',
+            'fecha' => '2024-05-10',
+            'municipio' => 'A',
+        ]);
+        ConferenciaNomada::create([
+            'tema_nomada_id' => $tema->id,
+            'titulo' => 'Conferencia junio',
+            'fecha' => '2024-06-10',
+            'municipio' => 'A',
+        ]);
+
+        $response = $this->getJson('/conferencias-nomada?mes=5');
+
+        $response->assertStatus(200)->assertJsonCount(1);
+    }
+
+    public function test_filtrar_por_municipio(): void
+    {
+        $tema = TemaNomada::create(['nombre' => 'Educacion']);
+        ConferenciaNomada::create([
+            'tema_nomada_id' => $tema->id,
+            'titulo' => 'Conf A',
+            'fecha' => '2024-05-10',
+            'municipio' => 'X',
+        ]);
+        ConferenciaNomada::create([
+            'tema_nomada_id' => $tema->id,
+            'titulo' => 'Conf B',
+            'fecha' => '2024-05-11',
+            'municipio' => 'Y',
+        ]);
+
+        $response = $this->getJson('/conferencias-nomada?municipio=X');
+
+        $response->assertStatus(200)->assertJsonCount(1)->assertJsonFragment(['municipio' => 'X']);
+    }
+}


### PR DESCRIPTION
## Summary
- add TemaNomada and ConferenciaNomada models, migrations and CRUD controllers
- link conferences to topics and support filtering by month or municipality
- introduce request validation and basic feature tests

## Testing
- `php artisan test` *(fails: Failed opening required vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68b204591948832fa44275e6c131894a