### PR TITLE
feat: add consultas psicologicas model and migration

### DIFF
--- a/backend/Sys_IPJ_2025/app/Models/ConsultaPsicologica.php
+++ b/backend/Sys_IPJ_2025/app/Models/ConsultaPsicologica.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ConsultaPsicologica extends Model
+{
+    use HasFactory;
+
+    protected $table = 'consultas_psicologicas';
+
+    protected $fillable = [
+        'beneficiario_id',
+        'fecha',
+        'hora',
+    ];
+
+    public function beneficiario()
+    {
+        return $this->belongsTo(Beneficiario::class);
+    }
+}

--- a/backend/Sys_IPJ_2025/database/migrations/2024_01_01_000013_create_consultas_psicologicas_table.php
+++ b/backend/Sys_IPJ_2025/database/migrations/2024_01_01_000013_create_consultas_psicologicas_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('consultas_psicologicas', function (Blueprint $table) {
+            $table->char('id', 36)->primary()->default(DB::raw('uuid()'));
+            $table->char('beneficiario_id', 36);
+            $table->date('fecha');
+            $table->time('hora');
+            $table->timestamps();
+
+            $table->foreign('beneficiario_id')
+                  ->references('id')
+                  ->on('beneficiarios')
+                  ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('consultas_psicologicas');
+    }
+};


### PR DESCRIPTION
## Summary
- add `consultas_psicologicas` migration
- add `ConsultaPsicologica` model with relation to `Beneficiario`

## Testing
- `composer install` *(fails: Required package laravel/breeze not present in lock file)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b205dac460832fb4965dd4df968bbd