### PR TITLE
feat: add psychological consultations controller and views

### DIFF
--- a/backend/Sys_IPJ_2025/app/Http/Controllers/ConsultaPsicologicaController.php
+++ b/backend/Sys_IPJ_2025/app/Http/Controllers/ConsultaPsicologicaController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ConsultaPsicologica;
+use App\Models\Beneficiario;
+use App\Http\Requests\ConsultaPsicologicaRequest;
+use Illuminate\Http\Request;
+
+class ConsultaPsicologicaController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        $beneficiarioId = $request->query('beneficiario_id');
+        $fecha = $request->query('fecha');
+
+        $consultas = ConsultaPsicologica::query()
+            ->when($beneficiarioId, fn($q) => $q->where('beneficiario_id', $beneficiarioId))
+            ->when($fecha, fn($q) => $q->where('fecha', $fecha))
+            ->orderByDesc('fecha')
+            ->paginate(10)
+            ->appends($request->only('beneficiario_id', 'fecha'));
+
+        $beneficiarios = Beneficiario::orderBy('nombre')->get();
+
+        return view('consultas-psicologicas.index', [
+            'consultas' => $consultas,
+            'beneficiarios' => $beneficiarios,
+            'beneficiario_id' => $beneficiarioId,
+            'fecha' => $fecha,
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        $beneficiarios = Beneficiario::orderBy('nombre')->get();
+
+        return view('consultas-psicologicas.create', compact('beneficiarios'));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(ConsultaPsicologicaRequest $request)
+    {
+        ConsultaPsicologica::create($request->validated());
+
+        return redirect()
+            ->route('consultas-psicologicas.index')
+            ->with('status', 'Consulta registrada');
+    }
+}

--- a/backend/Sys_IPJ_2025/app/Http/Requests/ConsultaPsicologicaRequest.php
+++ b/backend/Sys_IPJ_2025/app/Http/Requests/ConsultaPsicologicaRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ConsultaPsicologicaRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'beneficiario_id' => ['required', 'exists:beneficiarios,id'],
+            'fecha' => ['required', 'date'],
+            'hora' => ['required'],
+        ];
+    }
+}

--- a/backend/Sys_IPJ_2025/resources/views/consultas-psicologicas/create.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/consultas-psicologicas/create.blade.php
@@ -1,0 +1,8 @@
+<x-layout title="Nueva consulta psicológica">
+    <h1 class="mb-4">Nueva consulta psicológica</h1>
+    <form action="{{ route('consultas-psicologicas.store') }}" method="POST">
+        @csrf
+        @php($consulta = null)
+        @include('consultas-psicologicas.form')
+    </form>
+</x-layout>

--- a/backend/Sys_IPJ_2025/resources/views/consultas-psicologicas/form.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/consultas-psicologicas/form.blade.php
@@ -1,0 +1,18 @@
+<div class="mb-3">
+    <label for="beneficiario_id" class="form-label">Beneficiario</label>
+    <select class="form-select" id="beneficiario_id" name="beneficiario_id">
+        @foreach ($beneficiarios as $beneficiario)
+            <option value="{{ $beneficiario->id }}" @selected(old('beneficiario_id', $consulta->beneficiario_id ?? '') == $beneficiario->id)>
+                {{ $beneficiario->nombre }}
+            </option>
+        @endforeach
+    </select>
+    @error('beneficiario_id')
+        <div class="text-danger small">{{ $message }}</div>
+    @enderror
+</div>
+<x-form.input type="date" name="fecha" label="Fecha" :value="$consulta->fecha ?? null" />
+<x-form.input type="time" name="hora" label="Hora" :value="$consulta->hora ?? null" />
+<div class="text-end">
+    <button type="submit" class="btn btn-primary">Guardar</button>
+</div>

--- a/backend/Sys_IPJ_2025/resources/views/consultas-psicologicas/index.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/consultas-psicologicas/index.blade.php
@@ -1,0 +1,41 @@
+<x-layout title="Consultas psicológicas">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="h3">Consultas psicológicas</h1>
+        <a href="{{ route('consultas-psicologicas.create') }}" class="btn btn-primary">Nueva</a>
+    </div>
+    <form class="row g-2 mb-4" method="GET" action="{{ route('consultas-psicologicas.index') }}">
+        <div class="col-auto">
+            <select name="beneficiario_id" class="form-select">
+                <option value="">Todos los beneficiarios</option>
+                @foreach ($beneficiarios as $b)
+                    <option value="{{ $b->id }}" @selected($beneficiario_id == $b->id)>{{ $b->nombre }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div class="col-auto">
+            <input type="date" name="fecha" class="form-control" value="{{ $fecha }}">
+        </div>
+        <div class="col-auto">
+            <button class="btn btn-secondary" type="submit">Filtrar</button>
+        </div>
+    </form>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Beneficiario</th>
+                <th>Fecha</th>
+                <th>Hora</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($consultas as $consulta)
+                <tr>
+                    <td>{{ $consulta->beneficiario->nombre }}</td>
+                    <td>{{ $consulta->fecha }}</td>
+                    <td>{{ $consulta->hora }}</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+    {{ $consultas->links() }}
+</x-layout>

--- a/backend/Sys_IPJ_2025/routes/web.php
+++ b/backend/Sys_IPJ_2025/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\GrupoManejoController;
 use App\Http\Controllers\InscripcionManejoController;
 use App\Http\Controllers\TemaNomadaController;
 use App\Http\Controllers\ConferenciaNomadaController;
+use App\Http\Controllers\ConsultaPsicologicaController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -42,6 +43,9 @@ Route::post('inscripciones', [InscripcionManejoController::class, 'store'])
     ->name('inscripciones.store');
 Route::delete('inscripciones/{inscripcion}', [InscripcionManejoController::class, 'destroy'])
     ->name('inscripciones.destroy');
+
+Route::resource('consultas-psicologicas', ConsultaPsicologicaController::class)
+    ->only(['index', 'create', 'store']);
 
 Route::resource('temas-nomada', TemaNomadaController::class);
 Route::resource('conferencias-nomada', ConferenciaNomadaController::class);


### PR DESCRIPTION
## Summary
- add `ConsultaPsicologicaController` and request validation
- add blade views to create and list consultations
- register routes for psychological consultations

## Testing
- `composer install --no-dev --no-interaction` (fails: CONNECT tunnel failed, response 403)
- `php artisan test` (fails: vendor/autoload.php missing)


------
https://chatgpt.com/codex/tasks/task_e_68b20685f9c8832fbfd5fbe3862720dc