### PR TITLE
Add basic user role management

### DIFF
--- a/backend/Sys_IPJ_2025/app/Http/Controllers/UsuarioController.php
+++ b/backend/Sys_IPJ_2025/app/Http/Controllers/UsuarioController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class UsuarioController extends Controller
+{
+    /**
+     * List all users.
+     */
+    public function index()
+    {
+        return response()->json(User::all());
+    }
+
+    /**
+     * Assign a role to the given user.
+     */
+    public function assignRole(Request $request, User $user)
+    {
+        $data = $request->validate([
+            'role' => 'required|string',
+        ]);
+
+        $user->role = $data['role'];
+        $user->save();
+
+        return response()->json(['message' => 'Rol asignado correctamente']);
+    }
+
+    /**
+     * Reset the user's password.
+     */
+    public function resetPassword(User $user)
+    {
+        $newPassword = Str::random(12);
+        $user->password = Hash::make($newPassword);
+        $user->save();
+
+        return response()->json(['new_password' => $newPassword]);
+    }
+}

--- a/backend/Sys_IPJ_2025/app/Models/User.php
+++ b/backend/Sys_IPJ_2025/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**

--- a/backend/Sys_IPJ_2025/database/factories/UserFactory.php
+++ b/backend/Sys_IPJ_2025/database/factories/UserFactory.php
@@ -29,6 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'role' => 'user',
         ];
     }
 

--- a/backend/Sys_IPJ_2025/database/migrations/2024_01_01_000016_add_role_to_users_table.php
+++ b/backend/Sys_IPJ_2025/database/migrations/2024_01_01_000016_add_role_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default('user');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/backend/Sys_IPJ_2025/database/seeders/AdminUserSeeder.php
+++ b/backend/Sys_IPJ_2025/database/seeders/AdminUserSeeder.php
@@ -16,6 +16,7 @@ class AdminUserSeeder extends Seeder
                 'name' => 'Admin',
                 'password' => Hash::make('password'),
                 'email_verified_at' => now(),
+                'role' => 'admin',
             ]
         );
     }

--- a/backend/Sys_IPJ_2025/routes/web.php
+++ b/backend/Sys_IPJ_2025/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\ConferenciaNomadaController;
 use App\Http\Controllers\ConsultaPsicologicaController;
 use App\Http\Controllers\PeriodoEscolarController;
 use App\Http\Controllers\BecaController;
+use App\Http\Controllers\UsuarioController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -55,3 +56,7 @@ Route::resource('consultas-psicologicas', ConsultaPsicologicaController::class)
 
 Route::resource('temas-nomada', TemaNomadaController::class);
 Route::resource('conferencias-nomada', ConferenciaNomadaController::class);
+
+Route::get('usuarios', [UsuarioController::class, 'index'])->name('usuarios.index');
+Route::post('usuarios/{user}/rol', [UsuarioController::class, 'assignRole'])->name('usuarios.assignRole');
+Route::post('usuarios/{user}/restablecer-contrasena', [UsuarioController::class, 'resetPassword'])->name('usuarios.resetPassword');


### PR DESCRIPTION
## Summary
- add simple role column to users
- add UsuarioController for listing users, assigning roles, and resetting passwords
- wire up user routes and seed default roles

## Testing
- `composer install` *(fails: lock file out of date and package download blocked)*
- `php artisan test` *(fails: vendor/autoload.php missing due to install failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b337caaf38832f8935ec8f5d26a8c7