### PR TITLE
Add role-based dashboard and user admin views

### DIFF
--- a/backend/Sys_IPJ_2025/app/Http/Controllers/DashboardController.php
+++ b/backend/Sys_IPJ_2025/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Auth;
+
+class DashboardController extends Controller
+{
+    public function __invoke()
+    {
+        return match (Auth::user()->role) {
+            'admin' => redirect()->route('dashboards.admin'),
+            'bienestar' => redirect()->route('dashboards.bienestar'),
+            'psicologia' => redirect()->route('dashboards.psicologia'),
+            'nomadas' => redirect()->route('dashboards.nomadas'),
+            default => redirect('/'),
+        };
+    }
+}

--- a/backend/Sys_IPJ_2025/app/Http/Controllers/UsuarioController.php
+++ b/backend/Sys_IPJ_2025/app/Http/Controllers/UsuarioController.php
@@ -14,7 +14,13 @@ class UsuarioController extends Controller
      */
     public function index()
     {
-        return response()->json(User::all());
+        $usuarios = User::all();
+
+        if (request()->wantsJson()) {
+            return response()->json($usuarios);
+        }
+
+        return view('usuarios.index', compact('usuarios'));
     }
 
     /**
@@ -29,7 +35,11 @@ class UsuarioController extends Controller
         $user->role = $data['role'];
         $user->save();
 
-        return response()->json(['message' => 'Rol asignado correctamente']);
+        if ($request->expectsJson()) {
+            return response()->json(['message' => 'Rol asignado correctamente']);
+        }
+
+        return redirect()->route('usuarios.index')->with('status', 'Rol asignado correctamente');
     }
 
     /**
@@ -41,6 +51,10 @@ class UsuarioController extends Controller
         $user->password = Hash::make($newPassword);
         $user->save();
 
-        return response()->json(['new_password' => $newPassword]);
+        if (request()->expectsJson()) {
+            return response()->json(['new_password' => $newPassword]);
+        }
+
+        return redirect()->route('usuarios.index')->with('status', 'Contraseña restablecida: ' . $newPassword);
     }
 }

--- a/backend/Sys_IPJ_2025/resources/views/components/layout.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/components/layout.blade.php
@@ -13,6 +13,10 @@
     <a class="nav-link" href="{{ route('programas.index') }}">Programas</a>
     <a class="nav-link" href="{{ route('periodos-escolares.index') }}">Periodos Escolares</a>
     <a class="nav-link" href="{{ route('becas.index') }}">Becas</a>
+    @auth
+    <a class="nav-link" href="{{ route('dashboard') }}">Dashboard</a>
+    <a class="nav-link" href="{{ route('usuarios.index') }}">Usuarios</a>
+    @endauth
   </div>
 </nav>
 <div class="container">

--- a/backend/Sys_IPJ_2025/resources/views/dashboards/admin.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/dashboards/admin.blade.php
@@ -1,0 +1,3 @@
+<x-layout title="Dashboard Admin">
+    <h1 class="h3">Dashboard Admin</h1>
+</x-layout>

--- a/backend/Sys_IPJ_2025/resources/views/dashboards/bienestar.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/dashboards/bienestar.blade.php
@@ -1,0 +1,3 @@
+<x-layout title="Dashboard Bienestar">
+    <h1 class="h3">Dashboard Bienestar</h1>
+</x-layout>

--- a/backend/Sys_IPJ_2025/resources/views/dashboards/nomadas.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/dashboards/nomadas.blade.php
@@ -1,0 +1,3 @@
+<x-layout title="Dashboard Nómadas">
+    <h1 class="h3">Dashboard Nómadas</h1>
+</x-layout>

--- a/backend/Sys_IPJ_2025/resources/views/dashboards/psicologia.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/dashboards/psicologia.blade.php
@@ -1,0 +1,3 @@
+<x-layout title="Dashboard Psicología">
+    <h1 class="h3">Dashboard Psicología</h1>
+</x-layout>

--- a/backend/Sys_IPJ_2025/resources/views/usuarios/index.blade.php
+++ b/backend/Sys_IPJ_2025/resources/views/usuarios/index.blade.php
@@ -1,0 +1,38 @@
+<x-layout title="Usuarios">
+    <h1 class="h3 mb-3">Usuarios</h1>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Nombre</th>
+                <th>Email</th>
+                <th>Rol</th>
+                <th>Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($usuarios as $usuario)
+                <tr>
+                    <td>{{ $usuario->name }}</td>
+                    <td>{{ $usuario->email }}</td>
+                    <td>{{ $usuario->role }}</td>
+                    <td>
+                        <form method="POST" action="{{ route('usuarios.assignRole', $usuario) }}" class="d-inline">
+                            @csrf
+                            <select name="role" class="form-select form-select-sm d-inline w-auto">
+                                <option value="admin" @selected($usuario->role === 'admin')>admin</option>
+                                <option value="bienestar" @selected($usuario->role === 'bienestar')>bienestar</option>
+                                <option value="psicologia" @selected($usuario->role === 'psicologia')>psicologia</option>
+                                <option value="nomadas" @selected($usuario->role === 'nomadas')>nomadas</option>
+                            </select>
+                            <button class="btn btn-sm btn-primary" type="submit">Actualizar</button>
+                        </form>
+                        <form method="POST" action="{{ route('usuarios.resetPassword', $usuario) }}" class="d-inline">
+                            @csrf
+                            <button class="btn btn-sm btn-secondary" type="submit">Restablecer contraseña</button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</x-layout>

--- a/backend/Sys_IPJ_2025/routes/web.php
+++ b/backend/Sys_IPJ_2025/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\ConsultaPsicologicaController;
 use App\Http\Controllers\PeriodoEscolarController;
 use App\Http\Controllers\BecaController;
 use App\Http\Controllers\UsuarioController;
+use App\Http\Controllers\DashboardController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -57,6 +58,14 @@ Route::resource('consultas-psicologicas', ConsultaPsicologicaController::class)
 Route::resource('temas-nomada', TemaNomadaController::class);
 Route::resource('conferencias-nomada', ConferenciaNomadaController::class);
 
-Route::get('usuarios', [UsuarioController::class, 'index'])->name('usuarios.index');
-Route::post('usuarios/{user}/rol', [UsuarioController::class, 'assignRole'])->name('usuarios.assignRole');
-Route::post('usuarios/{user}/restablecer-contrasena', [UsuarioController::class, 'resetPassword'])->name('usuarios.resetPassword');
+Route::middleware('auth')->group(function () {
+    Route::get('usuarios', [UsuarioController::class, 'index'])->name('usuarios.index');
+    Route::post('usuarios/{user}/rol', [UsuarioController::class, 'assignRole'])->name('usuarios.assignRole');
+    Route::post('usuarios/{user}/restablecer-contrasena', [UsuarioController::class, 'resetPassword'])->name('usuarios.resetPassword');
+
+    Route::get('/dashboard', DashboardController::class)->name('dashboard');
+    Route::view('/admin', 'dashboards.admin')->name('dashboards.admin');
+    Route::view('/bienestar', 'dashboards.bienestar')->name('dashboards.bienestar');
+    Route::view('/psicologia', 'dashboards.psicologia')->name('dashboards.psicologia');
+    Route::view('/nomadas', 'dashboards.nomadas')->name('dashboards.nomadas');
+});

--- a/backend/Sys_IPJ_2025/tests/Feature/DashboardTest.php
+++ b/backend/Sys_IPJ_2025/tests/Feature/DashboardTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_user_is_redirected_to_admin_dashboard(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertRedirect('/admin');
+    }
+
+    public function test_bienestar_user_is_redirected_to_bienestar_dashboard(): void
+    {
+        $user = User::factory()->create(['role' => 'bienestar']);
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertRedirect('/bienestar');
+    }
+}


### PR DESCRIPTION
## Summary
- Add DashboardController redirecting users to role-specific dashboards
- Create admin user management view for assigning roles and resetting passwords
- Link dashboard and user admin from navigation

## Testing
- `composer install --no-dev` *(failed: required GitHub token)*
- `php artisan test` *(failed: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68b338bb39b8832fb2330f1777eba172